### PR TITLE
change types: struct Transaction.Timestamp string to int64

### DIFF
--- a/transactions.go
+++ b/transactions.go
@@ -25,7 +25,7 @@ type Transaction struct {
 	GasWanted int64  `json:"gasWanted"`
 	GasUsed   int64  `json:"gasUsed"`
 	Tx        Tx     `json:"tx"`
-	Timestamp string `json:"timestamp"`
+	Timestamp int64  `json:"timestamp"`
 }
 
 func (t *Transaction) Check() (err error) {


### PR DESCRIPTION
fixed test
```
--- FAIL: TestRetrieveTransactionInformation (0.05s)
    transactions_test.go:15: 
                Error Trace:    transactions_test.go:15
                Error:          Expected nil, but got: &json.UnmarshalTypeError{Value:"number", Type:(*reflect.rtype)(0x6f2ec0), Offset:1826, Struct:"Transaction", Field:"timestamp"}
                Test:           TestRetrieveTransactionInformation
```

**Breaking change:**

raw-transaction response document:
https://docs-blockchain.line.biz/api-guide/Callback-Response?id=raw-transaction

```
timestamp | String | Confirmation time of the block immediately previous to the block including the given transaction with the format of “YYYY-MM-DDThh:mm:ssZ.” Note that it’s NOT confirmation time of the block including the given transaction.
```

The documentation states that this response will be returned as a string in a particular format, but it seems that it is actually returned as UNIXTIME (ms).

