### PR TITLE
Update LBD type constructor

### DIFF
--- a/lbd.go
+++ b/lbd.go
@@ -54,10 +54,22 @@ type LBD struct {
 	Debug     bool
 }
 
-func NewLBD(apiKey string, secret string, owner *Wallet) (*LBD, error) {
+func NewCashew(apiKey string, secret string, owner *Wallet) (*LBD, error) {
 	l := &LBD{
 		Network:   Cashew,
 		baseURL:   CashewBaseURL,
+		apiKey:    apiKey,
+		apiSecret: secret,
+		Owner:     owner,
+		Debug:     false,
+	}
+	return l, nil
+}
+
+func NewDaphne(apiKey string, secret string, owner *Wallet) (*LBD, error) {
+	l := &LBD{
+		Network:   Daphne,
+		baseURL:   DaphneBaseURL,
 		apiKey:    apiKey,
 		apiSecret: secret,
 		Owner:     owner,

--- a/lbd.go
+++ b/lbd.go
@@ -54,10 +54,10 @@ type LBD struct {
 	Debug     bool
 }
 
-func NewCashew(apiKey string, secret string, owner *Wallet) (*LBD, error) {
+func NewLBD(network Network, url string, apiKey string, secret string, owner *Wallet) (*LBD, error) {
 	l := &LBD{
-		Network:   Cashew,
-		baseURL:   CashewBaseURL,
+		Network:   network,
+		baseURL:   url,
 		apiKey:    apiKey,
 		apiSecret: secret,
 		Owner:     owner,
@@ -66,16 +66,26 @@ func NewCashew(apiKey string, secret string, owner *Wallet) (*LBD, error) {
 	return l, nil
 }
 
+func NewCashew(apiKey string, secret string, owner *Wallet) (*LBD, error) {
+	l, err := NewLBD(
+		Cashew,
+		CashewBaseURL,
+		apiKey,
+		secret,
+		owner,
+	)
+	return l, err
+}
+
 func NewDaphne(apiKey string, secret string, owner *Wallet) (*LBD, error) {
-	l := &LBD{
-		Network:   Daphne,
-		baseURL:   DaphneBaseURL,
-		apiKey:    apiKey,
-		apiSecret: secret,
-		Owner:     owner,
-		Debug:     false,
-	}
-	return l, nil
+	l, err := NewLBD(
+		Daphne,
+		DaphneBaseURL,
+		apiKey,
+		secret,
+		owner,
+	)
+	return l, err
 }
 
 func (l LBD) Sign(r Requester) string {

--- a/lbd_test.go
+++ b/lbd_test.go
@@ -26,7 +26,7 @@ func TestSign(t *testing.T) {
 	nonce := "Bp0IqgXE"
 	timestamp := int64(1581850266351)
 
-	l, err := NewLBD(key, secret, nil)
+	l, err := NewCashew(key, secret, nil)
 	assert.Nil(err)
 
 	// Example 1
@@ -51,7 +51,7 @@ func TestSign(t *testing.T) {
 
 func TestMain(m *testing.M) {
 	var err error
-	l, err = NewLBD(os.Getenv("API_KEY"), os.Getenv("API_SECRET"), owner)
+	l, err = NewCashew(os.Getenv("API_KEY"), os.Getenv("API_SECRET"), owner)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Summary

Function NewLBD specified the network to Cashew (LBD testnet).  
So it gonna fixed to 2 type of constructor, NewCashew and NewDaphne.

__Breaking change__

- Function NewLBD interface has changed

We should use NewCashew or NewDaphne to create LBD instance instead.