### PR TITLE
Add RetrieveTheHolderOfSpecificNonFungible

### DIFF
--- a/itemtokens.go
+++ b/itemtokens.go
@@ -155,6 +155,7 @@ func (l *LBD) RetrieveNonFungibleInformation(contractId, tokenType, tokenIndex s
 	return ret, json.Unmarshal(resp.ResponseData, ret)
 }
 
+// Holders Response Struct
 type Holder struct {
 	WalletAddress *string `json:"walletAddress"`
 	UserID        *string `json:"userId"`
@@ -186,6 +187,25 @@ func (l LBD) RetrieveHolderOfSpecificNonFungible(contractId, tokenType string) (
 		}
 	}
 	return all, nil
+}
+
+type ItemTokenHolder struct {
+	WalletAddress *string `json:"walletAddress"`
+	UserID        *string `json:"userId"`
+	TokenID       *string `json:"tokenId"`
+	Amount        string  `json:"amount"`
+}
+
+func (l LBD) RetrieveTheHolderOfSpecificNonFungible(contractId, tokenType, tokenIndex string) (*ItemTokenHolder, error) {
+	path := fmt.Sprintf("/v1/item-tokens/%s/non-fungibles/%s/%s/holder", contractId, tokenType, tokenIndex)
+
+	r := NewGetRequest(path)
+	resp, err := l.Do(r, true)
+	if err != nil {
+		return nil, err
+	}
+	ret := new(ItemTokenHolder)
+	return ret, json.Unmarshal(resp.ResponseData, ret)
 }
 
 type MintNonFungibleRequest struct {

--- a/itemtokens_test.go
+++ b/itemtokens_test.go
@@ -39,3 +39,10 @@ func TestUpdateNonFungibleInformation(t *testing.T) {
 	assert.Nil(t, err)
 	t.Log(ret)
 }
+
+func TestRetrieveTheHolderOfSpecificNonFungible(t *testing.T) {
+	onlyTxMode(t)
+	ret, err := l.RetrieveTheHolderOfSpecificNonFungible(itemTokenContractId, tokenType, "00000001")
+	assert.Nil(t, err)
+	t.Log(ret)
+}


### PR DESCRIPTION
Implemented: Retrieve the holder of a specific non-fungible
https://docs-blockchain.line.biz/api-guide/category-item-tokens?id=v1-item-tokens-contractid-non-fungibles-tokentype-tokenindex-holder-get
