### PR TITLE
Unmarshal the return value of RetrieveNonFungibleTokenType function

### DIFF
--- a/itemtokens.go
+++ b/itemtokens.go
@@ -126,14 +126,15 @@ type NonFungibleTokenType struct {
 	Meta         string `json:"meta"`
 }
 
-func (l *LBD) RetrieveNonFungibleTokenType(contractId, tokenType string) ([]byte, error) {
+func (l *LBD) RetrieveNonFungibleTokenType(contractId, tokenType string) (*TokenType, error) {
 	path := fmt.Sprintf("/v1/item-tokens/%s/non-fungibles/%s", contractId, tokenType)
 	r := NewGetRequest(path)
 	resp, err := l.Do(r, true)
 	if err != nil {
 		return nil, err
 	}
-	return resp.ResponseData, nil
+	ret := new(TokenType)
+	return ret, json.Unmarshal(resp.ResponseData, ret)
 }
 
 type NonFungibleInformation struct {


### PR DESCRIPTION
Unmarshal the return value for ease of use.

https://docs-blockchain.line.biz/api-guide/category-item-tokens?id=v1-item-tokens-contractid-non-fungibles-tokentype-get