### PR TITLE
Fix RetrieveBalanceOfNonFungiblesWithTokenTypeUserWallet bug

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,6 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/users.go
+++ b/users.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"net/url"
+	"strconv"
 	"strings"
 )
 
@@ -370,10 +372,15 @@ type BalanceOfNonFungiblesToken struct {
 
 func (l LBD) RetrieveBalanceOfNonFungiblesWithTokenTypeUserWallet(userId, contractId, orderBy, pageToken string, limit uint32) (*BalanceOfNonFungiblesTokenType, error) {
 	var r *Request
+
+	q := url.Values{}
+	q.Add("limit", strconv.Itoa(int(limit)))
+	q.Add("orderBy", orderBy)
 	if pageToken == "" {
-		r = NewGetRequest(fmt.Sprintf("/v1/users/%s/item-tokens/%s/non-fungibles/with-type?limit=%d&orderBy=%s", userId, contractId, limit, orderBy))
+		r = NewGetRequestWithQuery(fmt.Sprintf("/v1/users/%s/item-tokens/%s/non-fungibles/with-type", userId, contractId), q)
 	} else {
-		r = NewGetRequest(fmt.Sprintf("/v1/users/%s/item-tokens/%s/non-fungibles/with-type?limit=%d&orderBy=%s&pageToken=%s", userId, contractId, limit, orderBy, pageToken))
+		q.Add("pageToken", pageToken)
+		r = NewGetRequestWithQuery(fmt.Sprintf("/v1/users/%s/item-tokens/%s/non-fungibles/with-type", userId, contractId), q)
 	}
 	resp, err := l.Do(r, true)
 	if err != nil {


### PR DESCRIPTION
We get error when using RetrieveBalanceOfNonFungiblesWithTokenTypeUserWallet.
Because the page token contains a string that needs to be URL encoded.
I add url.Values to Request struct for URL encode.
However, it must not be URL encoded when signing, according to the response from LINE's development team.