### PR TITLE
非推奨となったAPIをコメントで通知し代替APIを追加

### DIFF
--- a/itemtokens.go
+++ b/itemtokens.go
@@ -363,6 +363,7 @@ type FungibleTokenResponse struct {
 	DetailStatus string `json:"detailStatus"`
 }
 
+// Deprecated: Use RetrieveFungibleTokenMediaResourceStatus or RetrieveFungibleTokenThumbnailsStatus instead.
 func (l LBD) RetrieveTheStatusOfMultipleFungibleTokenIcons(contractId, requestId string) ([]*FungibleTokenResponse, error) {
 	path := fmt.Sprintf("/v1/item-tokens/%s/fungibles/icon/%s/status", contractId, requestId)
 
@@ -391,6 +392,7 @@ type NonFungibleTokenResponse struct {
 	DetailStatus string `json:"detailStatus"`
 }
 
+// Deprecated: Use RetrieveNonFungibleTokenMediaResourceStatus or RetrieveNonFungibleTokenThumbnailsStatus instead.
 func (l LBD) RetrieveTheStatusOfMultipleNonFungibleTokenIcons(contractId, requestId string) ([]*NonFungibleTokenResponse, error) {
 	path := fmt.Sprintf("/v1/item-tokens/%s/non-fungibles/icon/%s/status", contractId, requestId)
 
@@ -552,6 +554,10 @@ type UpdateMultipleFungibleTokenIconsRequest struct {
 	*Request
 	UpdateList []*UpdateFungibleList `json:"updateList"`
 }
+type UpdateMultipleFungibleTokenUpdateListRequest struct {
+	*Request
+	UpdateList []*UpdateFungibleList `json:"updateList"`
+}
 
 type UpdateList struct {
 	TokenType  string `json:"tokenType"`
@@ -563,6 +569,21 @@ type UpdateFungibleList struct {
 }
 
 func (r UpdateMultipleFungibleTokenIconsRequest) Encode() string {
+	base := r.Request.Encode()
+	types := make([]string, len(r.UpdateList))
+
+	for i, m := range r.UpdateList {
+		types[i] = m.TokenType
+	}
+	updateList := fmt.Sprintf("updateList.tokenType=%s",
+		strings.Join(types, ","),
+	)
+
+	ret := fmt.Sprintf("%s?%s", base, updateList)
+	return ret
+}
+
+func (r UpdateMultipleFungibleTokenUpdateListRequest) Encode() string {
 	base := r.Request.Encode()
 	types := make([]string, len(r.UpdateList))
 
@@ -595,7 +616,30 @@ func (r UpdateMultipleNonFungibleTokenIconsRequest) Encode() string {
 	return ret
 }
 
+func (r UpdateMultipleNonFungibleTokenUpdateListRequest) Encode() string {
+	base := r.Request.Encode()
+	types := make([]string, len(r.UpdateList))
+	indexes := make([]string, len(r.UpdateList))
+
+	for i, m := range r.UpdateList {
+		types[i] = m.TokenType
+		indexes[i] = m.TokenIndex
+	}
+	updateList := fmt.Sprintf("updateList.tokenIndex=%s&updateList.tokenType=%s",
+		strings.Join(indexes, ","),
+		strings.Join(types, ","),
+	)
+
+	ret := fmt.Sprintf("%s?%s", base, updateList)
+	return ret
+}
+
 type UpdateMultipleNonFungibleTokenIconsRequest struct {
+	*Request
+	UpdateList []*UpdateList `json:"updateList"`
+}
+
+type UpdateMultipleNonFungibleTokenUpdateListRequest struct {
 	*Request
 	UpdateList []*UpdateList `json:"updateList"`
 }
@@ -604,6 +648,15 @@ type UpdateMultipleTokenIconsResponse struct {
 	RequestId string `json:"requestId"`
 }
 
+type UpdateMediaResourcesResponse struct {
+	RequestId string `json:"requestId"`
+}
+
+type UpdateThumbnailsResponse struct {
+	RequestId string `json:"requestId"`
+}
+
+// Deprecated: Use UpdateNonFungibleTokenThumbnails or UpdateNonFungibleTokenMediaResources or  instead.
 func (l *LBD) UpdateMultipleNonFungibleTokenIcons(contactId string, updateList []*UpdateList) (*UpdateMultipleTokenIconsResponse, error) {
 	path := fmt.Sprintf("/v1/item-tokens/%s/non-fungibles/icon", contactId)
 
@@ -621,6 +674,7 @@ func (l *LBD) UpdateMultipleNonFungibleTokenIcons(contactId string, updateList [
 	return ret, json.Unmarshal(resp.ResponseData, &ret)
 }
 
+// Deprecated: Use UpdateFungibleTokenThumbnails or UpdateFungibleTokenMediaResources instead.
 func (l *LBD) UpdateMultipleFungibleTokenIcons(contactId string, updateList []*UpdateFungibleList) (*UpdateMultipleTokenIconsResponse, error) {
 	path := fmt.Sprintf("/v1/item-tokens/%s/fungibles/icon", contactId)
 
@@ -991,4 +1045,160 @@ func (l *LBD) BurnNonFungible(contractId, tokenType, tokenIndex, from string) (*
 		return nil, err
 	}
 	return UnmarshalTransaction(resp.ResponseData)
+}
+
+// Get media resource status for multiple fungible tokens
+func (l LBD) RetrieveFungibleTokenMediaResourceStatus(contractId, requestId string) ([]*FungibleTokenResponse, error) {
+	path := fmt.Sprintf("/v1/item-tokens/%s/fungibles/media-resources/%s/status", contractId, requestId)
+
+	r := NewGetRequest(path)
+
+	resp, err := l.Do(r, true)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := []*FungibleTokenResponse{}
+
+	err = json.Unmarshal(resp.ResponseData, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+// Get thumbnail status of multiple fungible tokens
+func (l LBD) RetrieveFungibleTokenThumbnailStatus(contractId, requestId string) ([]*FungibleTokenResponse, error) {
+	path := fmt.Sprintf("/v1/item-tokens/%s/fungibles/thumbnails/%s/status", contractId, requestId)
+
+	r := NewGetRequest(path)
+
+	resp, err := l.Do(r, true)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := []*FungibleTokenResponse{}
+
+	err = json.Unmarshal(resp.ResponseData, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+// Get media resource status for multiple non-fungible tokens
+func (l LBD) RetrieveNonFungibleTokenMediaResourceStatus(contractId, requestId string) ([]*NonFungibleTokenResponse, error) {
+	path := fmt.Sprintf("/v1/item-tokens/%s/non-fungibles/media-resources/%s/status", contractId, requestId)
+
+	r := NewGetRequest(path)
+
+	resp, err := l.Do(r, true)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := []*NonFungibleTokenResponse{}
+
+	err = json.Unmarshal(resp.ResponseData, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+// Get thumbnail status of multiple non-fungible tokens
+func (l LBD) RetrieveNonFungibleTokenThumbnailStatus(contractId, requestId string) ([]*NonFungibleTokenResponse, error) {
+	path := fmt.Sprintf("/v1/item-tokens/%s/non-fungibles/thumbnails/%s/status", contractId, requestId)
+
+	r := NewGetRequest(path)
+
+	resp, err := l.Do(r, true)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := []*NonFungibleTokenResponse{}
+
+	err = json.Unmarshal(resp.ResponseData, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+// Update media resources for multiple fungible tokens
+func (l *LBD) UpdateFungibleTokenMediaResources(contactId string, updateList []*UpdateFungibleList) (*UpdateMediaResourcesResponse, error) {
+	path := fmt.Sprintf("/v1/item-tokens/%s/fungibles/media-resources", contactId)
+
+	r := UpdateMultipleFungibleTokenUpdateListRequest{
+		Request:    NewPutRequest(path),
+		UpdateList: updateList,
+	}
+
+	resp, err := l.Do(r, true)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := new(UpdateMediaResourcesResponse)
+	return ret, json.Unmarshal(resp.ResponseData, &ret)
+}
+
+// Update thumbnails for multiple fungible tokens
+func (l *LBD) UpdateFungibleTokenThumbnails(contactId string, updateList []*UpdateFungibleList) (*UpdateThumbnailsResponse, error) {
+	path := fmt.Sprintf("/v1/item-tokens/%s/fungibles/thumbnails", contactId)
+
+	r := UpdateMultipleFungibleTokenUpdateListRequest{
+		Request:    NewPutRequest(path),
+		UpdateList: updateList,
+	}
+
+	resp, err := l.Do(r, true)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := new(UpdateThumbnailsResponse)
+	return ret, json.Unmarshal(resp.ResponseData, &ret)
+}
+
+// Update media resources for multiple non-fungible tokens
+func (l *LBD) UpdateNonFungibleTokenMediaResources(contactId string, updateList []*UpdateList) (*UpdateMediaResourcesResponse, error) {
+	path := fmt.Sprintf("/v1/item-tokens/%s/non-fungibles/media-resources", contactId)
+
+	r := UpdateMultipleNonFungibleTokenUpdateListRequest{
+		Request:    NewPutRequest(path),
+		UpdateList: updateList,
+	}
+
+	resp, err := l.Do(r, true)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := new(UpdateMediaResourcesResponse)
+	return ret, json.Unmarshal(resp.ResponseData, &ret)
+}
+
+// Update thumbnails for multiple non-fungible tokens
+func (l *LBD) UpdateNonFungibleTokenThumbnails(contactId string, updateList []*UpdateList) (*UpdateThumbnailsResponse, error) {
+	path := fmt.Sprintf("/v1/item-tokens/%s/non-fungibles/thumbnails", contactId)
+
+	r := UpdateMultipleNonFungibleTokenUpdateListRequest{
+		Request:    NewPutRequest(path),
+		UpdateList: updateList,
+	}
+
+	resp, err := l.Do(r, true)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := new(UpdateThumbnailsResponse)
+	return ret, json.Unmarshal(resp.ResponseData, &ret)
 }

--- a/itemtokens_test.go
+++ b/itemtokens_test.go
@@ -16,7 +16,7 @@ func TestListAllFungibles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Log(*ret[0])
+	t.Log(ret)
 }
 
 func TestRetrieveFungibleInformation(t *testing.T) {
@@ -39,7 +39,7 @@ func TestRetrieveAllFungibleHolders(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Log(*ret[0])
+	t.Log(ret)
 }
 
 func TestListAllNonFungibles(t *testing.T) {
@@ -53,7 +53,7 @@ func TestListAllNonFungibles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Log(*ret[1])
+	t.Log(ret)
 }
 
 func TestCreateNonFungible(t *testing.T) {
@@ -67,7 +67,7 @@ func TestCreateNonFungible(t *testing.T) {
 
 func TestRetrieveNonFungibleInformation(t *testing.T) {
 	onlyTxMode(t)
-	ret, err := l.RetrieveNonFungibleInformation(itemTokenContractId, tokenType, "00000001")
+	ret, err := l.RetrieveNonFungibleInformation(itemTokenContractId, nonFungibleTokenType, "00000001")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -76,7 +76,7 @@ func TestRetrieveNonFungibleInformation(t *testing.T) {
 
 func TestMintNonFungible(t *testing.T) {
 	onlyTxMode(t)
-	ret, err := l.MintNonFungible(itemTokenContractId, tokenType, "Nobnyaga", "uwawa", toAddress)
+	ret, err := l.MintNonFungible(itemTokenContractId, nonFungibleTokenType, "Nobnyaga", "uwawa", toAddress)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -111,7 +111,7 @@ func TestUpdateNonFungibleInformation(t *testing.T) {
 
 func TestRetrieveTheHolderOfSpecificNonFungible(t *testing.T) {
 	onlyTxMode(t)
-	ret, err := l.RetrieveTheHolderOfSpecificNonFungible(itemTokenContractId, tokenType, "00000001")
+	ret, err := l.RetrieveTheHolderOfSpecificNonFungible(itemTokenContractId, nonFungibleTokenType, "00000001")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -125,41 +125,25 @@ func TestListTheChildrenOfNonFungible(t *testing.T) {
 		OrderBy: "asc",
 		Limit:   DefaultLimit,
 	}
-	ret, err := l.ListTheChildrenOfNonFungible(itemTokenContractId, tokenType, "00000001", pager)
+	ret, err := l.ListTheChildrenOfNonFungible(itemTokenContractId, nonFungibleTokenType, "00000001", pager)
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Log(*ret[0])
+	t.Log(ret)
 }
 
 func TestRetrieveTheParentOfNonFungible(t *testing.T) {
 	onlyTxMode(t)
-	ret, err := l.RetrieveTheParentOfNonFungible(itemTokenContractId, tokenType, "00000001")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Log(ret)
-}
-func TestRetrieveTheRootOfNonFungible(t *testing.T) {
-	onlyTxMode(t)
-	ret, err := l.RetrieveTheRootOfNonFungible(itemTokenContractId, tokenType, "00000001")
+	ret, err := l.RetrieveTheParentOfNonFungible(itemTokenContractId, nonFungibleTokenType, "00000001")
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Log(ret)
 }
 
-func TestRetrieveTheStatusOfMultipleFungibleTokenIcons(t *testing.T) {
+func TestRetrieveTheRootOfNonFungible(t *testing.T) {
 	onlyTxMode(t)
-	ret, err := l.RetrieveTheStatusOfMultipleFungibleTokenIcons(itemTokenContractId, "63f34026-ffef-4dcf-a512-746f3e512378")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Log(ret)
-}
-func TestRetrieveTheStatusOfMultipleNonFungibleTokenIcons(t *testing.T) {
-	onlyTxMode(t)
-	ret, err := l.RetrieveTheStatusOfMultipleNonFungibleTokenIcons(itemTokenContractId, "df6629c7-f1b6-4a82-81b4-6cc3083c2785")
+	ret, err := l.RetrieveTheRootOfNonFungible(itemTokenContractId, nonFungibleTokenType, "00000001")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -206,7 +190,7 @@ func TestUpdateFungibleInformation(t *testing.T) {
 
 func TestAttachNonFungibleAnother(t *testing.T) {
 	onlyTxMode(t)
-	ret, err := l.AttachNonFungibleAnother(itemTokenContractId, tokenType, "00000001", " 1000000600000001", userId)
+	ret, err := l.AttachNonFungibleAnother(itemTokenContractId, nonFungibleTokenType, "00000001", " 1000000600000001", userId)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -215,7 +199,7 @@ func TestAttachNonFungibleAnother(t *testing.T) {
 
 func TestDetachNonFungibleParent(t *testing.T) {
 	onlyTxMode(t)
-	ret, err := l.DetachNonFungibleParent(itemTokenContractId, tokenType, "00000001", userId)
+	ret, err := l.DetachNonFungibleParent(itemTokenContractId, nonFungibleTokenType, "00000001", userId)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -242,7 +226,7 @@ func TestMintFungible(t *testing.T) {
 
 func TestBurnFungible(t *testing.T) {
 	onlyTxMode(t)
-	ret, err := l.BurnFungible(itemTokenContractId, tokenType, toAddress, big.NewInt(1000))
+	ret, err := l.BurnFungible(itemTokenContractId, fungibleTokenType, toAddress, big.NewInt(1000))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -287,7 +271,7 @@ func TestMintMultipleNonFungible(t *testing.T) {
 	onlyTxMode(t)
 	mintList := []*MintList{
 		{
-			TokenType: tokenType,
+			TokenType: nonFungibleTokenType,
 			Name:      name,
 			Meta:      meta,
 		},
@@ -302,7 +286,7 @@ func TestMintMultipleNonFungible(t *testing.T) {
 
 func TestBurnNonFungible(t *testing.T) {
 	onlyTxMode(t)
-	ret, err := l.BurnNonFungible(itemTokenContractId, tokenType, "00000001", toAddress)
+	ret, err := l.BurnNonFungible(itemTokenContractId, nonFungibleTokenType, "00000001", toAddress)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -312,7 +296,10 @@ func TestBurnNonFungible(t *testing.T) {
 func TestRetrieveFungibleTokenMediaResourceStatus(t *testing.T) {
 	onlyTxMode(t)
 
-	ret, err := l.RetrieveFungibleTokenMediaResourceStatus(itemTokenContractId, "63f34026-ffef-4dcf-a512-746f3e512378")
+	updateList := []*UpdateFungibleList{{TokenType: "00000002"}}
+	updateRet, _ := l.UpdateFungibleTokenMediaResources(itemTokenContractId, updateList)
+
+	ret, err := l.RetrieveFungibleTokenMediaResourceStatus(itemTokenContractId, updateRet.RequestId)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -320,8 +307,9 @@ func TestRetrieveFungibleTokenMediaResourceStatus(t *testing.T) {
 }
 
 func TestRetrieveFungibleTokenThumbnailStatus(t *testing.T) {
-
-	ret, err := l.RetrieveFungibleTokenThumbnailStatus(itemTokenContractId, "63f34026-ffef-4dcf-a512-746f3e512378")
+	updateList := []*UpdateFungibleList{{TokenType: "00000002"}}
+	updateRet, _ := l.UpdateFungibleTokenThumbnails(itemTokenContractId, updateList)
+	ret, err := l.RetrieveFungibleTokenThumbnailStatus(itemTokenContractId, updateRet.RequestId)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -329,8 +317,9 @@ func TestRetrieveFungibleTokenThumbnailStatus(t *testing.T) {
 }
 
 func TestRetrieveNonFungibleTokenMediaResourceStatus(t *testing.T) {
-
-	ret, err := l.RetrieveNonFungibleTokenMediaResourceStatus(itemTokenContractId, "df6629c7-f1b6-4a82-81b4-6cc3083c2785")
+	updateList := []*UpdateList{{TokenType: "10000001", TokenIndex: "00000001"}}
+	updateRet, _ := l.UpdateNonFungibleTokenMediaResources(itemTokenContractId, updateList)
+	ret, err := l.RetrieveNonFungibleTokenMediaResourceStatus(itemTokenContractId, updateRet.RequestId)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -338,7 +327,9 @@ func TestRetrieveNonFungibleTokenMediaResourceStatus(t *testing.T) {
 }
 
 func TestRetrieveNonFungibleTokenThumbnailStatus(t *testing.T) {
-	ret, err := l.RetrieveNonFungibleTokenThumbnailStatus(itemTokenContractId, "df6629c7-f1b6-4a82-81b4-6cc3083c2785")
+	updateList := []*UpdateList{{TokenType: "10000001", TokenIndex: "00000001"}}
+	updateRet, _ := l.UpdateNonFungibleTokenThumbnails(itemTokenContractId, updateList)
+	ret, err := l.RetrieveNonFungibleTokenThumbnailStatus(itemTokenContractId, updateRet.RequestId)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -346,11 +337,7 @@ func TestRetrieveNonFungibleTokenThumbnailStatus(t *testing.T) {
 }
 
 func TestUpdateFungibleTokenMediaResources(t *testing.T) {
-	updateList := []*UpdateFungibleList{
-		{
-			TokenType: "10000002",
-		},
-	}
+	updateList := []*UpdateFungibleList{{TokenType: fungibleTokenType}}
 	ret, err := l.UpdateFungibleTokenMediaResources(itemTokenContractId, updateList)
 	if err != nil {
 		t.Fatal(err)
@@ -359,11 +346,7 @@ func TestUpdateFungibleTokenMediaResources(t *testing.T) {
 }
 
 func TestUpdateFungibleTokenThumbnails(t *testing.T) {
-	updateList := []*UpdateFungibleList{
-		{
-			TokenType: "10000002",
-		},
-	}
+	updateList := []*UpdateFungibleList{{TokenType: fungibleTokenType}}
 	ret, err := l.UpdateFungibleTokenThumbnails(itemTokenContractId, updateList)
 	if err != nil {
 		t.Fatal(err)
@@ -372,12 +355,7 @@ func TestUpdateFungibleTokenThumbnails(t *testing.T) {
 }
 
 func TestUpdateNonFungibleTokenMediaResources(t *testing.T) {
-	updateList := []*UpdateList{
-		{
-			TokenType:  "10000001",
-			TokenIndex: "10000003",
-		},
-	}
+	updateList := []*UpdateList{{TokenType: nonFungibleTokenType, TokenIndex: "00000001"}}
 	ret, err := l.UpdateNonFungibleTokenMediaResources(itemTokenContractId, updateList)
 	if err != nil {
 		t.Fatal(err)
@@ -386,12 +364,7 @@ func TestUpdateNonFungibleTokenMediaResources(t *testing.T) {
 }
 
 func TestUpdateNonFungibleTokenThumbnails(t *testing.T) {
-	updateList := []*UpdateList{
-		{
-			TokenType:  "10000001",
-			TokenIndex: "10000003",
-		},
-	}
+	updateList := []*UpdateList{{TokenType: nonFungibleTokenType, TokenIndex: "00000001"}}
 	ret, err := l.UpdateNonFungibleTokenThumbnails(itemTokenContractId, updateList)
 	if err != nil {
 		t.Fatal(err)

--- a/itemtokens_test.go
+++ b/itemtokens_test.go
@@ -308,3 +308,93 @@ func TestBurnNonFungible(t *testing.T) {
 	}
 	t.Log(ret)
 }
+
+func TestRetrieveFungibleTokenMediaResourceStatus(t *testing.T) {
+	onlyTxMode(t)
+
+	ret, err := l.RetrieveFungibleTokenMediaResourceStatus(itemTokenContractId, "63f34026-ffef-4dcf-a512-746f3e512378")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(ret)
+}
+
+func TestRetrieveFungibleTokenThumbnailStatus(t *testing.T) {
+
+	ret, err := l.RetrieveFungibleTokenThumbnailStatus(itemTokenContractId, "63f34026-ffef-4dcf-a512-746f3e512378")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(ret)
+}
+
+func TestRetrieveNonFungibleTokenMediaResourceStatus(t *testing.T) {
+
+	ret, err := l.RetrieveNonFungibleTokenMediaResourceStatus(itemTokenContractId, "df6629c7-f1b6-4a82-81b4-6cc3083c2785")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(ret)
+}
+
+func TestRetrieveNonFungibleTokenThumbnailStatus(t *testing.T) {
+	ret, err := l.RetrieveNonFungibleTokenThumbnailStatus(itemTokenContractId, "df6629c7-f1b6-4a82-81b4-6cc3083c2785")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(ret)
+}
+
+func TestUpdateFungibleTokenMediaResources(t *testing.T) {
+	updateList := []*UpdateFungibleList{
+		{
+			TokenType: "10000002",
+		},
+	}
+	ret, err := l.UpdateFungibleTokenMediaResources(itemTokenContractId, updateList)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(ret)
+}
+
+func TestUpdateFungibleTokenThumbnails(t *testing.T) {
+	updateList := []*UpdateFungibleList{
+		{
+			TokenType: "10000002",
+		},
+	}
+	ret, err := l.UpdateFungibleTokenThumbnails(itemTokenContractId, updateList)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(ret)
+}
+
+func TestUpdateNonFungibleTokenMediaResources(t *testing.T) {
+	updateList := []*UpdateList{
+		{
+			TokenType:  "10000001",
+			TokenIndex: "10000003",
+		},
+	}
+	ret, err := l.UpdateNonFungibleTokenMediaResources(itemTokenContractId, updateList)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(ret)
+}
+
+func TestUpdateNonFungibleTokenThumbnails(t *testing.T) {
+	updateList := []*UpdateList{
+		{
+			TokenType:  "10000001",
+			TokenIndex: "10000003",
+		},
+	}
+	ret, err := l.UpdateNonFungibleTokenThumbnails(itemTokenContractId, updateList)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(ret)
+}

--- a/lbd_test.go
+++ b/lbd_test.go
@@ -11,8 +11,8 @@ var (
 	owner                  = NewWallet(os.Getenv("OWNER_ADDR"), os.Getenv("OWNER_SECRET"))
 	itemTokenContractId    = os.Getenv("ITEMTOKEN_CONTRACT_ID")
 	serviceTokenContractId = os.Getenv("SERVICETOKEN_CONTRACT_ID")
-	tokenType              = "10000001"
 	fungibleTokenType      = "00000001"
+	nonFungibleTokenType   = "10000001"
 	userId                 = os.Getenv("USER_ID")
 	toAddress              = userId
 	sessionToken           = os.Getenv("SESSION")

--- a/servicewallets_test.go
+++ b/servicewallets_test.go
@@ -36,7 +36,7 @@ func TestRetrieveServiceWalletTransactionHistory(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Log(len(ret))
-	t.Log(*ret[0])
+	t.Log(ret)
 }
 
 func TestRetrieveBaseCoinBalance(t *testing.T) {
@@ -58,7 +58,7 @@ func TestRetrieveBalanceAllServiceTokens(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Log(len(ret))
-	t.Log(*ret[0])
+	t.Log(ret)
 }
 
 func TestRetrieveBalanceSpecificServiceTokenWallet(t *testing.T) {
@@ -80,11 +80,11 @@ func TestRetrieveBalanceAllFungibles(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Log(len(ret))
-	t.Log(*ret[0])
+	t.Log(ret)
 }
 
 func TestRetrieveBalanceSpecificFungible(t *testing.T) {
-	ret, err := l.RetrieveBalanceSpecificFungible(owner.Address, itemTokenContractId, tokenType)
+	ret, err := l.RetrieveBalanceSpecificFungible(owner.Address, itemTokenContractId, fungibleTokenType)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -92,7 +92,7 @@ func TestRetrieveBalanceSpecificFungible(t *testing.T) {
 }
 
 func TestRetrieveBalanceSpecificNonFungible(t *testing.T) {
-	ret, err := l.RetrieveBalanceSpecificNonFungible(owner.Address, itemTokenContractId, tokenType, "00000001")
+	ret, err := l.RetrieveBalanceSpecificNonFungible(owner.Address, itemTokenContractId, nonFungibleTokenType, "00000001")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -109,7 +109,7 @@ func TestTransferServiceTokens(t *testing.T) {
 }
 
 func TestTransferFungible(t *testing.T) {
-	ret, err := l.TransferFungible(owner, serviceTokenContractId, toAddress, tokenType, big.NewInt(1000))
+	ret, err := l.TransferFungible(owner, serviceTokenContractId, toAddress, fungibleTokenType, big.NewInt(1000))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -120,10 +120,10 @@ func TestBatchTransferNonFungible(t *testing.T) {
 
 	transferList := []*TransferList{
 		{
-			TokenId: tokenType + "00000001",
+			TokenId: nonFungibleTokenType + "00000001",
 		},
 		{
-			TokenId: tokenType + "00000002",
+			TokenId: nonFungibleTokenType + "00000002",
 		},
 	}
 	ret, err := l.BatchTransferNonFungible(owner.Address, itemTokenContractId, toAddress, transferList)

--- a/users_test.go
+++ b/users_test.go
@@ -19,7 +19,7 @@ func TestRetrieveUserWalletTransactionHistory(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Log(len(ret))
-	t.Log(*ret[0])
+	t.Log(ret)
 }
 
 func TestIssueSessionTokenForBaseCoinTransfer(t *testing.T) {
@@ -33,7 +33,7 @@ func TestIssueSessionTokenForBaseCoinTransfer(t *testing.T) {
 
 func TestFuncTransferNonFungibleUserWallet(t *testing.T) {
 	onlyTxMode(t)
-	ret, err := l.TransferNonFungibleUserWallet(itemTokenContractId, userId, "tlink10ps670a0x6ma5knthjjswgw89d44vmz6xm3umr", tokenType, "00000009")
+	ret, err := l.TransferNonFungibleUserWallet(itemTokenContractId, userId, "tlink10ps670a0x6ma5knthjjswgw89d44vmz6xm3umr", nonFungibleTokenType, "00000009")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,7 +131,7 @@ func TestRetrieveBalanceOfNonFungiblesWithTokenTypeUserWallet(t *testing.T) {
 }
 
 func TestRetrieveBalanceOfSpecificNonFungibleUserWallet(t *testing.T) {
-	ret, err := l.RetrieveBalanceOfSpecificNonFungibleUserWallet(userId, itemTokenContractId, tokenType, "00000001")
+	ret, err := l.RetrieveBalanceOfSpecificNonFungibleUserWallet(userId, itemTokenContractId, nonFungibleTokenType, "00000001")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -181,7 +181,7 @@ func TestTransferDelegatedServiceTokenUserWallet(t *testing.T) {
 }
 
 func TestTransferDelegatedFungibleUserWallet(t *testing.T) {
-	ret, err := l.TransferDelegatedFungibleUserWallet(userId, itemTokenContractId, tokenType, owner.Address, big.NewInt(1000))
+	ret, err := l.TransferDelegatedFungibleUserWallet(userId, itemTokenContractId, fungibleTokenType, owner.Address, big.NewInt(1000))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -189,7 +189,7 @@ func TestTransferDelegatedFungibleUserWallet(t *testing.T) {
 }
 
 func TestTransferDelegatedNonFungible(t *testing.T) {
-	ret, err := l.TransferDelegatedNonFungible(userId, itemTokenContractId, tokenType, "00000001", owner.Address)
+	ret, err := l.TransferDelegatedNonFungible(userId, itemTokenContractId, nonFungibleTokenType, "00000001", owner.Address)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -197,7 +197,7 @@ func TestTransferDelegatedNonFungible(t *testing.T) {
 }
 
 func TestBatchTransferDelegatedNonFungiblesUserWallet(t *testing.T) {
-	ret, err := l.BatchTransferDelegatedNonFungiblesUserWallet(userId, itemTokenContractId, owner.Address, []TransferList{{TokenId: tokenType + "00000001"}, {TokenId: tokenType + "00000002"}})
+	ret, err := l.BatchTransferDelegatedNonFungiblesUserWallet(userId, itemTokenContractId, owner.Address, []TransferList{{TokenId: nonFungibleTokenType + "00000001"}, {TokenId: nonFungibleTokenType + "00000002"}})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/utils_test.go
+++ b/utils_test.go
@@ -27,7 +27,7 @@ func TestRetrieveUserHoldersFungibles(t *testing.T) {
 }
 
 func TestListBalanceOfSpecificTypeOfNonFungiblesUserWallet(t *testing.T) {
-	ret, err := l.ListBalanceOfSpecificTypeOfNonFungiblesUserWallet(userId, itemTokenContractId, tokenType)
+	ret, err := l.ListBalanceOfSpecificTypeOfNonFungiblesUserWallet(userId, itemTokenContractId, nonFungibleTokenType)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,7 +43,7 @@ func TestRetrieveWalletAddressBalanceOfAllNonFungiblesServiceWallet(t *testing.T
 }
 
 func TestRetrieveWalletAddressBalanceOfSpecificTypeOfNonFungiblesServiceWallet(t *testing.T) {
-	ret, err := l.RetrieveWalletAddressBalanceOfSpecificTypeOfNonFungiblesServiceWallet(owner.Address, itemTokenContractId, tokenType)
+	ret, err := l.RetrieveWalletAddressBalanceOfSpecificTypeOfNonFungiblesServiceWallet(owner.Address, itemTokenContractId, nonFungibleTokenType)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -83,7 +83,7 @@ func TestRetrieveAllFungibleHoldersItemToken(t *testing.T) {
 }
 
 func TestRetrieveHolderOfSpecificNonFungibleItemToken(t *testing.T) {
-	ret, err := l.RetrieveHolderOfSpecificNonFungibleItemToken(itemTokenContractId, tokenType)
+	ret, err := l.RetrieveHolderOfSpecificNonFungibleItemToken(itemTokenContractId, nonFungibleTokenType)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,7 +91,7 @@ func TestRetrieveHolderOfSpecificNonFungibleItemToken(t *testing.T) {
 }
 
 func TestListTheChildrenOfNonFungibleItemToken(t *testing.T) {
-	ret, err := l.ListTheChildrenOfNonFungibleItemToken(itemTokenContractId, tokenType, "00000001")
+	ret, err := l.ListTheChildrenOfNonFungibleItemToken(itemTokenContractId, nonFungibleTokenType, "00000001")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -107,7 +107,7 @@ func TestListAllNonFungiblesItemToken(t *testing.T) {
 }
 
 func TestUpdateMultipleNonFungibleTokenIconsCache(t *testing.T) {
-	err := l.UpdateMultipleNonFungibleTokenIconsCache([]string{tokenType + "00000001"}, itemTokenContractId)
+	err := l.UpdateMultipleNonFungibleTokenIconsCache([]string{nonFungibleTokenType + "00000001"}, itemTokenContractId)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
### 非推奨となったAPI

- [Retrieve the status of multiple fungible token icons](https://docs-blockchain.line.biz/api-guide/category-item-tokens/retrieve#v1-item-tokens-contractId-fungibles-icon-request-id-status-get)
- [Retrieve the status of multiple non-fungible token icons](https://docs-blockchain.line.biz/api-guide/category-item-tokens/retrieve#v1-item-tokens-contractId-non-fungibles-icon-request-id-status-get)
- [Retrieve the status of multiple fungible token icons](https://docs-blockchain.line.biz/api-guide/category-item-tokens/retrieve#v1-item-tokens-contractId-fungibles-icon-request-id-status-get)
- [Update multiple non-fungible token icons
](https://docs-blockchain.line.biz/api-guide/category-item-tokens/update#v1-item-tokens-contractId-non-fungibles-icon-put)

### 新しく追加されたAPI

- [Retrieve the status of multiple fungible token media resources](https://docs-blockchain.line.biz/api-guide/category-item-tokens/retrieve#v1-item-tokens-contractId-fungibles-media-resources-request-id-status-get)
- [Retrieve the status of multiple fungible token thumbnails](https://docs-blockchain.line.biz/api-guide/category-item-tokens/retrieve#v1-item-tokens-contractId-fungibles-thumbnails-request-id-status-get)
- [Retrieve the status of multiple non-fungible token media resources](https://docs-blockchain.line.biz/api-guide/category-item-tokens/retrieve#v1-item-tokens-contractId-non-fungibles-media-resources-request-id-status-get)
- [Retrieve the status of multiple non-fungible token thumbnails](https://docs-blockchain.line.biz/api-guide/category-item-tokens/retrieve#v1-item-tokens-contractId-non-fungibles-thumbnails-request-id-status-get)
- [Update multiple fungible token media resources](https://docs-blockchain.line.biz/api-guide/category-item-tokens/update#v1-item-tokens-contractId-fungibles-media-resource-put)
- [Update multiple fungible token thumbnails](https://docs-blockchain.line.biz/api-guide/category-item-tokens/update#v1-item-tokens-contractId-fungibles-thumbnails-put)
- [Update multiple non-fungible token media resources](https://docs-blockchain.line.biz/api-guide/category-item-tokens/update#v1-item-tokens-contractId-non-fungibles-media-resource-put)
- [Update multiple non-fungible token thumbnails](https://docs-blockchain.line.biz/api-guide/category-item-tokens/update#v1-item-tokens-contractId-non-fungibles-thumbnails-put)
