### PR TITLE
staticcheckによるワーニングチェックを解消

### DIFF
--- a/itemtokens.go
+++ b/itemtokens.go
@@ -19,10 +19,10 @@ func NewMeta() *Meta {
 
 func (m *Meta) Set(key, value string) (err error) {
 	if len(key) < 1 && 15 < len(key) {
-		return fmt.Errorf("Invalid key length")
+		return fmt.Errorf("invalid key length")
 	}
 	if len(value) < 1 && 15 < len(value) {
-		return fmt.Errorf("Invalid value length")
+		return fmt.Errorf("invalid value length")
 	}
 	m.data[key] = value
 	return nil


### PR DESCRIPTION
vscodeのGoのエクステンションをインストールしている場合ですが、
デフォルトのlinterが[staticcheck](https://staticcheck.io/)に設定されています。

https://github.com/golang/vscode-go/wiki/features#lint-errors

vscodeのGoのエクステンション及び、staticcheckは GO言語の開発者が開発しているようでLinterとしては間違い無いのではと。