### PR TITLE
プロキシ関連の対応

### DIFF
--- a/users_test.go
+++ b/users_test.go
@@ -42,7 +42,7 @@ func TestFuncTransferNonFungibleUserWallet(t *testing.T) {
 
 func TestIssueSessionTokenForProxySetting(t *testing.T) {
 	onlyTxMode(t)
-	ret, err := l.IssueSessionTokenForProxySetting(userId, itemTokenContractId, RequestTypeAOA)
+	ret, err := l.IssueSessionTokenForProxySetting(userId, itemTokenContractId, "https://my.service.landing/home", RequestTypeAOA)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
新しく追加されたAPI
[アイテムトークンのproxy設定用のセッショントークンの状態を取得する](https://docs-blockchain.line.biz/ja/api-guide/category-users/retrieve#v1-users-userId-item-tokens-contractId-proxy-get)


変更されたAPI
・LandingUriを設定
[アイテムトークンの管理権限を委任するためのセッショントークンを発行する](https://docs-blockchain.line.biz/ja/api-guide/category-users/issue#v1-users-userId-item-tokens-contractId-request-proxy-post)